### PR TITLE
[BAR] Fix Borders and Add "ABC" Alert

### DIFF
--- a/GCDWheel.cs
+++ b/GCDWheel.cs
@@ -1,0 +1,316 @@
+﻿
+using Dalamud.Game;
+using Dalamud.Logging;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using GCDTracker.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Tests")]
+namespace GCDTracker {
+    public record AbilityTiming(float AnimationLock, bool IsCasted);
+
+    public unsafe class GCDWheel {
+        public Dictionary<float, AbilityTiming> ogcds = [];
+        public float TotalGCD;
+
+        private DateTime lastGCDEnd;
+        private float lastElapsedGCD;
+        private bool lastActionCast;
+        private float lastClipDelta;
+        private bool clippedGCD;
+        private bool checkClip;
+        private bool showABCAlert;
+        private ulong targetBuffer;
+        private ulong hackBuffer;
+        public float SecondsSinceGCDEnd =>
+            lastElapsedGCD > 0 ? 0 : (float)(DateTime.Now - lastGCDEnd).TotalSeconds;
+        public GCDWheel() {
+            TotalGCD = 3.5f;
+            lastGCDEnd = DateTime.Now;
+            lastActionCast = false;
+            lastClipDelta = 0f;
+            clippedGCD = false;
+            checkClip = false;
+            showABCAlert = false; 
+            targetBuffer = 1;
+        }
+
+        public void OnActionUse(byte ret, ActionManager* actionManager, ActionType actionType, uint actionID, ulong targetedActorID, uint param, uint useType, int pvp) {
+            var act = DataStore.Action;
+
+            var isWeaponSkill = HelperMethods.IsWeaponSkill(actionType, actionID);
+            var addingToQueue = HelperMethods.IsAddingToQueue(isWeaponSkill, act) && useType != 1;
+            var executingQueued = act->InQueue && !addingToQueue;
+            
+            //check to make sure that the player is targeting something, so that if they are spamming an action
+            //button after the mob dies it won't update the targetBuffer and trigger an ABC
+            if (DataStore.ClientState.LocalPlayer?.TargetObject != null)
+            targetBuffer = DataStore.ClientState.LocalPlayer.TargetObjectId;
+            if (ret != 1) {
+                if (executingQueued && Math.Abs(act->ElapsedCastTime-act->TotalCastTime)<0.0001f && isWeaponSkill)
+                    ogcds.Clear();
+                return;
+            }
+            if (addingToQueue) {
+                AddToQueue(act, isWeaponSkill);
+            } else {
+                if (isWeaponSkill) {
+                    EndCurrentGCD(TotalGCD);
+                    //Store GCD in a variable in order to cache it when it goes back to 0
+                    TotalGCD = act->TotalGCD;
+                    AddWeaponSkill(act);
+                } else if (!executingQueued) {
+                    ogcds[act->ElapsedGCD] = new(act->AnimationLock, false);
+                }
+            }
+        }
+
+        private void AddToQueue(Data.Action* act, bool isWeaponSkill) {
+            var timings = new List<float>() {
+                isWeaponSkill ? act->TotalGCD : 0, // Weapon skills
+            };
+            if (!act->IsCast) {
+                // Add OGCDs
+                timings.Add(act->ElapsedGCD + act->AnimationLock);
+            } else if (act->ElapsedCastTime < act->TotalGCD) {
+                // Add Casts
+                timings.Add(act->TotalCastTime + 0.1f);
+            } else {
+                // Add Casts after 1 whole GCD of casting
+                timings.Add(act->TotalCastTime - act->ElapsedCastTime + 0.1f);
+            }
+            ogcds[timings.Max()] = new(0.64f, false);
+        }
+
+        private void AddWeaponSkill(Data.Action* act) {
+            if (act->IsCast) {
+                lastActionCast = true;
+                ogcds[0f] = new(0.1f, false);
+                ogcds[act->TotalCastTime] = new(0.1f, true);
+            } else {
+                ogcds[0f] = new(act->AnimationLock, false);
+            }
+        }
+
+        public void Update(IFramework framework) {
+            if (DataStore.ClientState.LocalPlayer == null)
+                return;
+
+            CleanFailedOGCDs();
+            if (lastActionCast && !HelperMethods.IsCasting())
+                HandleCancelCast();
+            else if (DataStore.Action->ElapsedGCD < lastElapsedGCD)
+                EndCurrentGCD(lastElapsedGCD);
+            else if (DataStore.Action->ElapsedGCD < 0.0001f)
+                SlideGCDs((float)(framework.UpdateDelta.TotalMilliseconds * 0.001), false);
+
+            //someone who knows how to code can probably come up with a way better solution to this problem.
+            //we cache whatever the targetid was when we called OnActionUse and compare it to whatever it is
+            //now.  hackBuffer because I couldn't get conditional to be true without it (something to do
+            //with the type cast going on to ulong, probably)
+            hackBuffer = DataStore.ClientState.LocalPlayer.TargetObjectId;
+            if (hackBuffer == targetBuffer)
+                //flag for alert if more than 50ms but less than 100ms have passed with no GCD in queue
+                showABCAlert = SecondsSinceGCDEnd >= 0.05f && SecondsSinceGCDEnd < 0.1f;
+
+            lastElapsedGCD = DataStore.Action->ElapsedGCD;
+        }
+
+        private void CleanFailedOGCDs() {
+            if (DataStore.Action->AnimationLock == 0 && ogcds.Count > 0) {
+                ogcds = ogcds
+                    .Where(x => x.Key > DataStore.Action->ElapsedGCD || x.Key + x.Value.AnimationLock < DataStore.Action->ElapsedGCD)
+                    .ToDictionary(x => x.Key, x => x.Value);
+            }
+        }
+
+        private void HandleCancelCast() {
+            lastActionCast = false;
+            EndCurrentGCD(DataStore.Action->TotalCastTime);
+        }
+
+        /// <summary>
+        /// This function slides all the GCDs forward by a delta and deletes the ones that reach 0
+        /// </summary>
+        internal void SlideGCDs(float delta, bool isOver) {
+            if (delta <= 0) return; //avoid problem with float precision
+            var ogcdsNew = new Dictionary<float, AbilityTiming>();
+            foreach (var (k, (v,vt)) in ogcds) {
+                if (k < -0.1) { } //remove from dictionary
+                else if (k < delta && v > delta) {
+                    ogcdsNew[k] = new(v - delta, vt);
+                } else if (k > delta) {
+                    ogcdsNew[k - delta] = new(v, vt);
+                } else if (isOver && k + v > TotalGCD) {
+                    ogcdsNew[0] = new(k + v - delta, vt);
+                    if (k < delta - 0.02f) // Ignore things that are queued or queued + cast end animation lock
+                        lastClipDelta = k + v - delta;
+                }
+            }
+            ogcds = ogcdsNew;
+        }
+
+        private bool ShouldStartClip() {
+            checkClip = false;
+            clippedGCD = lastClipDelta > 0.01f;
+            return clippedGCD;
+        }
+
+        public void DrawGCDWheel(PluginUI ui, Configuration conf) {
+            float gcdTotal = TotalGCD;
+            float gcdTime = lastElapsedGCD;
+            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
+                gcdTime = gcdTotal;
+            if (gcdTotal < 0.1f) return;
+            if (checkClip && ShouldStartClip()) {
+                ui.StartClip(lastClipDelta);
+                lastClipDelta = 0;
+            }
+            if (showABCAlert && !clippedGCD) {
+                ui.StartABC();
+                showABCAlert = false;
+            }
+            if (clippedGCD && lastGCDEnd + TimeSpan.FromSeconds(4) < DateTime.Now)
+                clippedGCD = false;
+
+            var backgroundCol = clippedGCD && conf.ColorClipEnabled ? conf.clipCol : conf.backCol;
+            // Background
+            ui.DrawCircSegment(0f, 1f, 6f * ui.Scale, conf.backColBorder); 
+            ui.DrawCircSegment(0f, 1f, 3f * ui.Scale, backgroundCol);
+            if (conf.WheelQueueLockEnabled) {
+                ui.DrawCircSegment(0.8f, 1, 9f * ui.Scale, conf.backColBorder); 
+                ui.DrawCircSegment(0.8f, 1, 6f * ui.Scale, backgroundCol);
+            }
+            if (conf.ClipAlertEnabled)
+                ui.DrawClip(0.5f, 0, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
+            if (conf.abcAlertEnabled)
+                ui.DrawABC(0.5f, 0, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
+
+            ui.DrawCircSegment(0f, Math.Min(gcdTime / gcdTotal, 1f), 20f * ui.Scale, conf.frontCol);
+
+            foreach (var (ogcd, (anlock, iscast)) in ogcds) {
+                var isClipping = CheckClip(iscast, ogcd, anlock, gcdTotal, gcdTime);
+                ui.DrawCircSegment(ogcd / gcdTotal, (ogcd + anlock) / gcdTotal, 21f * ui.Scale, isClipping ? conf.clipCol : conf.anLockCol);
+                if (!iscast) ui.DrawCircSegment(ogcd / gcdTotal, (ogcd + 0.04f) / gcdTotal, 23f * ui.Scale, conf.ogcdCol);
+            }
+        }
+
+        public void DrawGCDBar(PluginUI ui, Configuration conf) {
+            float gcdTotal = TotalGCD;
+            float gcdTime = lastElapsedGCD;
+            if (HelperMethods.IsCasting() && DataStore.Action->ElapsedCastTime >= gcdTotal && !HelperMethods.IsTeleport(DataStore.Action->CastId))
+                gcdTime = gcdTotal;
+            if (gcdTotal < 0.1f) return;
+            if (checkClip && ShouldStartClip()) {
+                ui.StartClip(lastClipDelta);
+                lastClipDelta = 0;
+            }
+            if (showABCAlert && !clippedGCD) {
+                ui.StartABC();
+                showABCAlert = false;
+            }
+            if (clippedGCD && lastGCDEnd + TimeSpan.FromSeconds(4) < DateTime.Now)
+                clippedGCD = false;
+                
+            var backgroundCol = clippedGCD && conf.BarColorClipEnabled ? conf.BarclipCol : conf.BarBackCol;
+            float barHeight = ui.w_size.Y * conf.BarHeightRatio;
+            float barWidth = ui.w_size.X * conf.BarWidthRatio;
+            float borderSize = conf.BarBorderSize;
+
+            Vector2 start = new(ui.w_cent.X - barWidth / 2, ui.w_cent.Y - barHeight / 2);
+            Vector2 end = new(ui.w_cent.X + barWidth / 2, ui.w_cent.Y + barHeight / 2);
+            // Background
+            ui.DrawBar(0f, 1f, barWidth, barHeight, backgroundCol);
+            if (conf.BarClipAlertEnabled)
+                ui.DrawClip((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
+            if (conf.BarABCAlertEnabled)
+                ui.DrawABC((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarABCTextSize, conf.BarABCTextColor, conf.BarABCBackColor);
+            ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.BarFrontCol);
+
+            float barGCDClipTime = 0;
+            foreach (var (ogcd, (anlock, iscast)) in ogcds) {
+                var isClipping = CheckClip(iscast, ogcd, anlock, gcdTotal, gcdTime);
+                float ogcdStart = (conf.BarRollGCDs && gcdTotal - ogcd < 0.2f) ? 0 + barGCDClipTime : ogcd;
+                float ogcdEnd = ogcdStart + anlock;
+                // Ends next GCD
+                if (conf.BarRollGCDs && ogcdEnd > gcdTotal) {
+                    ogcdEnd = gcdTotal;
+                    barGCDClipTime += ogcdStart + anlock - gcdTotal;
+                    
+                    // Draw the clipped part at the beggining
+                    ui.DrawBar(0, barGCDClipTime/gcdTotal, barWidth, barHeight, conf.BarclipCol);
+                }
+                
+                ui.DrawBar(ogcdStart / gcdTotal, ogcdEnd / gcdTotal, barWidth, barHeight, isClipping ? conf.BarclipCol : conf.BarAnLockCol);
+                if (!iscast && (!isClipping || ogcdStart > 0.01f)) {
+                    Vector2 clipPos = new(
+                        ui.w_cent.X + (ogcdStart / gcdTotal * barWidth) - (barWidth / 2),
+                        ui.w_cent.Y - (barHeight / 2) + 1f
+                    );
+                    ui.DrawRectFilled(clipPos,
+                        clipPos + new Vector2(2f*ui.Scale, barHeight-2f),
+                        conf.BarOgcdCol);
+                }
+            }
+            //borders last so they're on top of all elements
+            if (borderSize > 0) {
+                ui.DrawRect(
+                    start - new Vector2(borderSize, borderSize)/2,
+                    end + new Vector2(borderSize, borderSize)/2,
+                    conf.BarBackColBorder, borderSize);
+            }
+            if (conf.BarQueueLockEnabled) {
+                Vector2 queueLock = new(
+                    ui.w_cent.X + (0.8f * barWidth) - (barWidth / 2),
+                    ui.w_cent.Y - (barHeight / 2) - (borderSize / 2)
+                );
+                ui.DrawRectFilled(queueLock,
+                    queueLock + new Vector2(borderSize, barHeight + (borderSize / 2)),
+                    conf.BarBackColBorder);
+            }
+        }
+
+        private bool CheckClip(bool iscast, float ogcd, float anlock, float gcdTotal, float gcdTime) =>
+            !iscast && DateTime.Now > lastGCDEnd + TimeSpan.FromMilliseconds(50)  &&
+            (
+                (ogcd < (gcdTotal - 0.05f) && ogcd + anlock > gcdTotal) // You will clip next GCD
+                || (gcdTime < 0.001f && ogcd < 0.001f && (anlock > (lastActionCast? 0.125:0.025))) // anlock when no gcdRolling nor CastEndAnimation
+            );
+        
+
+        private void EndCurrentGCD(float GCDtime) {
+            SlideGCDs(GCDtime, true);
+            if (lastElapsedGCD > 0) checkClip = true;
+            lastElapsedGCD = DataStore.Action->ElapsedGCD;
+            lastGCDEnd = DateTime.Now;
+        }
+
+        public void UpdateAnlock(float oldLock, float newLock) {
+            if (oldLock == newLock) return; //Ignore autoattacks
+            if (ogcds.Count == 0) return;
+            if (oldLock == 0) { //End of cast
+                lastActionCast = false;
+                return;
+            }
+            var ctime = DataStore.Action->ElapsedGCD;
+
+            var items = ogcds.Where(x => x.Key <= ctime && ctime < x.Key + x.Value.AnimationLock);
+            if (!items.Any()) return;
+            var item = items.First(); //Should always be one
+
+            ogcds[item.Key] = new(ctime - item.Key + newLock, item.Value.IsCasted);
+            var diff = newLock - oldLock;
+            var toSlide = ogcds.Where(x => x.Key > ctime).ToList();
+            foreach (var ogcd in toSlide)
+                ogcds[ogcd.Key + diff] = ogcd.Value;
+            foreach (var ogcd in toSlide)
+                ogcds.Remove(ogcd.Key);
+        }
+    }
+
+}

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -29,12 +29,15 @@ namespace GCDTracker
         public bool WheelQueueLockEnabled = true;
         public bool ColorClipEnabled = true;
         public bool ClipAlertEnabled = true;
+        public bool abcAlertEnabled = true;
         public int ClipAlertPrecision = 0;
         public float ClipTextSize = 0.86f;
+        public float abcTextSize = 0.8f;
         public Vector4 clipCol = new(1f, 0f, 0f, 0.667f);
         public Vector4 ClipTextColor = new(0.9f, 0.9f, 0.9f, 1f);
         public Vector4 ClipBackColor = new(1f, 0f, 0f, 1f);
-
+        public Vector4 abcTextColor = new(0f, 0f, 0f, 1f);
+        public Vector4 abcBackColor = new(1f, .7f, 0f, 1f);
         public Vector4 backCol = new(0.376f, 0.376f, 0.376f, 1);
         public Vector4 backColBorder = new(0f, 0f, 0f, 1f);
         public Vector4 frontCol = new(0.9f, 0.9f, 0.9f, 1f);
@@ -50,12 +53,16 @@ namespace GCDTracker
         public bool BarQueueLockEnabled = true;
         public bool BarColorClipEnabled = true;
         public bool BarClipAlertEnabled = true;
+        public bool BarABCAlertEnabled = true;
         public int BarClipAlertPrecision = 0;
         public bool BarRollGCDs = true;
         public float BarClipTextSize = 0.8f;
+        public float BarABCTextSize = 0.8f;
         public Vector4 BarclipCol = new(1f, 0f, 0f, 0.667f);
         public Vector4 BarClipTextColor = new(0.9f, 0.9f, 0.9f, 1f);
         public Vector4 BarClipBackColor = new(1f, 0f, 0f, 1f);
+        public Vector4 BarABCTextColor = new(0f, 0f, 0f, 1f);
+        public Vector4 BarABCBackColor = new(1f, .7f, 0f, 1f);
         public float BarBorderSize = 2f;
         public float BarWidthRatio = 0.9f;
         public float BarHeightRatio = 0.5f;
@@ -244,6 +251,15 @@ namespace GCDTracker
                         }
                         ImGui.Separator();
 
+                        ImGui.Checkbox("Show ABC failure alert", ref abcAlertEnabled);
+                        if (abcAlertEnabled) {
+                            ImGui.ColorEdit4("ABC text color", ref abcTextColor, ImGuiColorEditFlags.NoInputs);
+                            ImGui.SameLine();
+                            ImGui.ColorEdit4("ABC background color", ref abcBackColor, ImGuiColorEditFlags.NoInputs);
+                        }
+                        ImGui.SliderFloat("Clip text size", ref abcTextSize, 0.2f, 2f);
+                        ImGui.Separator();
+
                         ImGui.Checkbox("Color wheel on clipped GCD", ref ColorClipEnabled);
                         ImGui.Checkbox("Show clip alert", ref ClipAlertEnabled);
                         if (ClipAlertEnabled) {
@@ -298,6 +314,15 @@ namespace GCDTracker
                         }
 
                         ImGui.Separator();
+                        ImGui.Checkbox("Show ABC failure alert", ref BarABCAlertEnabled);
+                        if (BarABCAlertEnabled) {
+                            ImGui.ColorEdit4("ABC text color", ref BarABCTextColor, ImGuiColorEditFlags.NoInputs);
+                            ImGui.SameLine();
+                            ImGui.ColorEdit4("ABC background color", ref BarABCBackColor, ImGuiColorEditFlags.NoInputs);
+                        }
+                        ImGui.SliderFloat("Clip text size", ref BarABCTextSize, 0.2f, 2f);
+                        ImGui.Separator();
+
                         ImGui.Checkbox("Color bar on clipped GCD", ref BarColorClipEnabled);
                         ImGui.Checkbox("Show clip alert", ref BarClipAlertEnabled);
                         if (BarClipAlertEnabled) {

--- a/src/GCDWheel.cs
+++ b/src/GCDWheel.cs
@@ -202,12 +202,7 @@ namespace GCDTracker {
                 ui.DrawClip((conf.BarWidthRatio + 1) / 2, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
 
             ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.BarFrontCol);
-            if (borderSize > 0) {
-                ui.DrawRect(
-                    start - new Vector2(borderSize, borderSize)/2,
-                    end + new Vector2(borderSize, borderSize)/2,
-                    conf.BarBackColBorder, borderSize);
-            }
+
             float barGCDClipTime = 0;
             foreach (var (ogcd, (anlock, iscast)) in ogcds) {
                 var isClipping = CheckClip(iscast, ogcd, anlock, gcdTotal, gcdTime);
@@ -232,6 +227,13 @@ namespace GCDTracker {
                         clipPos + new Vector2(2f*ui.Scale, barHeight-2f),
                         conf.BarOgcdCol);
                 }
+            }
+            //borders last so they're on top of all elements
+            if (borderSize > 0) {
+                ui.DrawRect(
+                    start - new Vector2(borderSize, borderSize)/2,
+                    end + new Vector2(borderSize, borderSize)/2,
+                    conf.BarBackColBorder, borderSize);
             }
             if (conf.BarQueueLockEnabled) {
                 Vector2 queueLock = new(

--- a/src/GCDWheel.cs
+++ b/src/GCDWheel.cs
@@ -1,4 +1,4 @@
-﻿
+
 using Dalamud.Game;
 using Dalamud.Logging;
 using Dalamud.Plugin.Services;
@@ -186,7 +186,7 @@ namespace GCDTracker {
             if (conf.ClipAlertEnabled)
                 ui.DrawClip(0.5f, 0, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
             if (conf.abcAlertEnabled)
-                ui.DrawABC(0.8f, 0, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
+                ui.DrawABC(0.5f, 0, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
 
             ui.DrawCircSegment(0f, Math.Min(gcdTime / gcdTotal, 1f), 20f * ui.Scale, conf.frontCol);
 
@@ -226,7 +226,7 @@ namespace GCDTracker {
             if (conf.BarClipAlertEnabled)
                 ui.DrawClip((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
             if (conf.BarABCAlertEnabled)
-                ui.DrawABC(((conf.BarWidthRatio + 1) / 1.9f) - conf.BarWidthRatio, -0.3f, conf.BarABCTextSize, conf.BarABCTextColor, conf.BarABCBackColor);
+                ui.DrawABC((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarABCTextSize, conf.BarABCTextColor, conf.BarABCBackColor);
             ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.BarFrontCol);
 
             float barGCDClipTime = 0;

--- a/src/GCDWheel.cs
+++ b/src/GCDWheel.cs
@@ -24,7 +24,9 @@ namespace GCDTracker {
         private float lastClipDelta;
         private bool clippedGCD;
         private bool checkClip;
-
+        private bool showABCAlert;
+        private ulong targetBuffer;
+        private ulong hackBuffer;
         public float SecondsSinceGCDEnd =>
             lastElapsedGCD > 0 ? 0 : (float)(DateTime.Now - lastGCDEnd).TotalSeconds;
         public GCDWheel() {
@@ -34,6 +36,8 @@ namespace GCDTracker {
             lastClipDelta = 0f;
             clippedGCD = false;
             checkClip = false;
+            showABCAlert = false; 
+            targetBuffer = 1;
         }
 
         public void OnActionUse(byte ret, ActionManager* actionManager, ActionType actionType, uint actionID, ulong targetedActorID, uint param, uint useType, int pvp) {
@@ -42,7 +46,8 @@ namespace GCDTracker {
             var isWeaponSkill = HelperMethods.IsWeaponSkill(actionType, actionID);
             var addingToQueue = HelperMethods.IsAddingToQueue(isWeaponSkill, act) && useType != 1;
             var executingQueued = act->InQueue && !addingToQueue;
-
+            
+            targetBuffer = DataStore.ClientState.LocalPlayer.TargetObjectId;
             if (ret != 1) {
                 if (executingQueued && Math.Abs(act->ElapsedCastTime-act->TotalCastTime)<0.0001f && isWeaponSkill)
                     ogcds.Clear();
@@ -100,6 +105,16 @@ namespace GCDTracker {
                 EndCurrentGCD(lastElapsedGCD);
             else if (DataStore.Action->ElapsedGCD < 0.0001f)
                 SlideGCDs((float)(framework.UpdateDelta.TotalMilliseconds * 0.001), false);
+
+            //someone who knows how to code can probably come up with a way better solution to this problem.
+            //we cache whatever the targetid was when we called OnActionUse and compare it to whatever it is
+            //now.  hackBuffer because I couldn't get conditional to be true without it (something to do
+            //with the type cast going on to ulong, probably)
+            hackBuffer = DataStore.ClientState.LocalPlayer.TargetObjectId;
+            if (hackBuffer == targetBuffer)
+                //flag for alert if more than 50ms but less than 100ms have passed with no GCD in queue
+                showABCAlert = SecondsSinceGCDEnd >= 0.05f && SecondsSinceGCDEnd < 0.1f;
+
             lastElapsedGCD = DataStore.Action->ElapsedGCD;
         }
 
@@ -153,6 +168,10 @@ namespace GCDTracker {
                 ui.StartClip(lastClipDelta);
                 lastClipDelta = 0;
             }
+            if (showABCAlert && !clippedGCD) {
+                ui.StartABC();
+                showABCAlert = false;
+            }
             if (clippedGCD && lastGCDEnd + TimeSpan.FromSeconds(4) < DateTime.Now)
                 clippedGCD = false;
 
@@ -166,6 +185,8 @@ namespace GCDTracker {
             }
             if (conf.ClipAlertEnabled)
                 ui.DrawClip(0.5f, 0, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
+            if (conf.abcAlertEnabled)
+                ui.DrawABC(0.8f, 0, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor);
 
             ui.DrawCircSegment(0f, Math.Min(gcdTime / gcdTotal, 1f), 20f * ui.Scale, conf.frontCol);
 
@@ -186,6 +207,10 @@ namespace GCDTracker {
                 ui.StartClip(lastClipDelta);
                 lastClipDelta = 0;
             }
+            if (showABCAlert && !clippedGCD) {
+                ui.StartABC();
+                showABCAlert = false;
+            }
             if (clippedGCD && lastGCDEnd + TimeSpan.FromSeconds(4) < DateTime.Now)
                 clippedGCD = false;
                 
@@ -199,8 +224,9 @@ namespace GCDTracker {
             // Background
             ui.DrawBar(0f, 1f, barWidth, barHeight, backgroundCol);
             if (conf.BarClipAlertEnabled)
-                ui.DrawClip((conf.BarWidthRatio + 1) / 2, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
-
+                ui.DrawClip((conf.BarWidthRatio + 1) / 2.1f, -0.3f, conf.BarClipTextSize, conf.BarClipTextColor, conf.BarClipBackColor, conf.BarClipAlertPrecision);
+            if (conf.BarABCAlertEnabled)
+                ui.DrawABC(((conf.BarWidthRatio + 1) / 1.9f) - conf.BarWidthRatio, -0.3f, conf.BarABCTextSize, conf.BarABCTextColor, conf.BarABCBackColor);
             ui.DrawBar(0f, Math.Min(gcdTime / gcdTotal, 1f), barWidth, barHeight, conf.BarFrontCol);
 
             float barGCDClipTime = 0;

--- a/src/PluginUI.cs
+++ b/src/PluginUI.cs
@@ -16,6 +16,8 @@ namespace GCDTracker
         public bool IsVisible { get; set; }
         private readonly Easing clipAnimAlpha;
         private readonly Easing clipAnimPos;
+        private readonly Easing abcAnimAlpha;
+        private readonly Easing abcAnimPos;
         public GCDWheel gcd;
         public ComboTracker ct;
         public Configuration conf;
@@ -36,6 +38,15 @@ namespace GCDTracker
                 Point1 = new(0, 0),
                 Point2 = new(0, -20)
             };
+            abcAnimAlpha = new OutCubic(new(0, 0, 0, 2, 1000)) {
+                Point1 = new(0.25f, 0),
+                Point2 = new(1f, 0)
+            };
+            abcAnimPos = new OutCubic(new(0, 0, 0, 1, 500)) {
+                Point1 = new(0, 0),
+                Point2 = new(0, -20)
+            };
+
             clipText = ["CLIP", "0.0", "0.00"];
         }
 
@@ -190,6 +201,44 @@ namespace GCDTracker
                 textStartPos + animPos,
                 ImGui.GetColorU32(textCol.WithAlpha(1-animAlpha)),
                 clipText[clipTextPrecision]);
+
+            ImGui.SetWindowFontScale(1f);
+            ImGui.PopFont();
+        } 
+
+        public void StartABC() {
+            if (!conf.abcAlertEnabled && !conf.BarABCAlertEnabled) return;
+            abcAnimAlpha.Restart();
+            abcAnimPos.Restart();
+        }
+        public void DrawABC(float relx, float rely, float textSize, Vector4 textCol, Vector4 backCol) {
+            if (!abcAnimAlpha.IsRunning || abcAnimAlpha.IsDone) return;
+
+            ImGui.PushFont(UiBuilder.MonoFont);
+            ImGui.SetWindowFontScale(textSize);
+
+            var textSz = ImGui.CalcTextSize("ABC");
+            var textStartPos =
+                w_cent
+                - (w_size / 2)
+                + new Vector2(w_size.X * relx, w_size.Y * rely)
+                - (textSz / 2);
+            var padding = new Vector2(10, 5) * textSize;
+
+            if (!abcAnimAlpha.IsDone) abcAnimAlpha.Update();
+            if (!abcAnimPos.IsDone) abcAnimPos.Update();
+
+            var animAlpha = abcAnimAlpha.EasedPoint.X;
+            var animPos = abcAnimPos.EasedPoint;
+
+            draw.AddRectFilled(
+                textStartPos - padding + animPos,
+                textStartPos + textSz + padding + animPos,
+                ImGui.GetColorU32(backCol.WithAlpha(1-animAlpha)), 10f);
+            draw.AddText(
+                textStartPos + animPos,
+                ImGui.GetColorU32(textCol.WithAlpha(1-animAlpha)),
+                "ABC");
 
             ImGui.SetWindowFontScale(1f);
             ImGui.PopFont();


### PR DESCRIPTION
Seems to fix the issue where the clipped portion of the bar is drawn above the borders of the GCDBar.  Also adds an "Always-Be-Casting" alert that reuses the CLIP alert code to display an alert when you let the GCD expire without starting another cast.  Will need some refactoring -- I'm not experienced with C# or Dalamud.