### PR TITLE
More Visible Slide/Queue Notifications

### DIFF
--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -55,11 +55,15 @@ namespace GCDTracker
         public bool WheelEnabled = true;
         [JsonIgnore]
         public bool WindowMoveableGW = false;
+        public bool pulseWheelAtQueue = false;
 
         //GCDBar
         public bool BarEnabled = false;
         [JsonIgnore]
         public bool BarWindowMoveable = false;
+        public bool pulseBarColorAtQueue = false;
+        public bool pulseBarWidthAtQueue = false;
+        public bool pulseBarHeightAtQueue = false;
         public bool BarQueueLockWhenIdle = true;
         public bool BarQueueLockSlide = false;
         public bool BarRollGCDs = true;
@@ -616,6 +620,14 @@ namespace GCDTracker
                             ImGui.Text("If enabled, use Monospace font in GCDTracker.");
                             ImGui.EndTooltip();
                         }
+                        ImGui.Checkbox("Pulse GCDBar Color @ Queue Lock", ref pulseBarColorAtQueue);
+                        ImGui.Checkbox("Pulse GCDBar Width @ Queue Lock", ref pulseBarWidthAtQueue);
+                        ImGui.Checkbox("Pulse GCDBar Height @ Queue Lock", ref pulseBarHeightAtQueue);
+                        ImGui.Checkbox("Pulse GCDWheel Size @ Queue Lock", ref pulseWheelAtQueue);
+                        ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);
+                        ImGui.Checkbox("Move/resize Triangles", ref WindowMoveableSQI);
+                        if (WindowMoveableSQI)
+                            ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                         ImGui.NewLine();
                         if (ImGui.Button("Reset All Settings to Default"))
                             showResetConfirmation = true;
@@ -643,13 +655,6 @@ namespace GCDTracker
                             ImGui.EndPopup();
                         }
                     }
-                    ImGui.EndTabItem();
-                }
-                if (ImGui.BeginTabItem("Triangles")) {
-                    ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);
-                    ImGui.Checkbox("Move/resize Triangles", ref WindowMoveableSQI);
-                    if (WindowMoveableSQI)
-                        ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                     ImGui.EndTabItem();
                 }
             }

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -105,6 +105,11 @@ namespace GCDTracker
         public Vector4 ctComboActive = new(1f, 1f, 1f, 1f);
         public Vector2 ctsep = new(23, 23);
 
+        //Floating Triangles
+        public bool FloatingTrianglesEnable = false;
+        [JsonIgnore]
+        public bool WindowMoveableSQI = false;
+
         //Deprecated
         public bool ShowOutOfCombatGW = false;
         public bool BarShowOutOfCombat = false;
@@ -638,6 +643,13 @@ namespace GCDTracker
                             ImGui.EndPopup();
                         }
                     }
+                    ImGui.EndTabItem();
+                }
+                if (ImGui.BeginTabItem("Triangles")) {
+                    ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);
+                    ImGui.Checkbox("Move/resize Triangles", ref WindowMoveableSQI);
+                    if (WindowMoveableSQI)
+                        ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");
                     ImGui.EndTabItem();
                 }
             }

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -34,6 +34,8 @@ namespace GCDTracker
         public bool ColorABCEnabled = false;
         [JsonIgnore]
         private bool showResetConfirmation = false;
+        [JsonIgnore]
+        private bool showColorConfirmation = false;
         public int ClipAlertPrecision = 0;
         public float GCDTimeout = 2f;
         public int abcDelay = 10;
@@ -672,6 +674,91 @@ namespace GCDTracker
                             }
                             ImGui.EndPopup();
                         }
+                        if (ImGui.Button("Reset Colors to Default"))
+                            showColorConfirmation = true;
+                        if (showColorConfirmation)
+                            ImGui.OpenPopup("Color Reset Confirmation");
+                        if (ImGui.BeginPopupModal("Color Reset Confirmation", ref showColorConfirmation, ImGuiWindowFlags.AlwaysAutoResize)) {
+                            ImGui.Text("This will reset your color settings.\nPlease choose an option:");
+                            ImGui.Separator();
+                            if (ImGui.Button("Use Default Colors")) {
+                                ResetColors(new Dictionary<string, object> {
+                                    { nameof(clipCol), new Vector4(1f, 0f, 0f, 0.667f) },
+                                    { nameof(abcCol), new Vector4(1f, 0.7f, 0f, 0.667f) },
+                                    { nameof(ClipTextColor), new Vector4(0.9f, 0.9f, 0.9f, 1f) },
+                                    { nameof(ClipBackColor), new Vector4(1f, 0f, 0f, 1f) },
+                                    { nameof(abcTextColor), new Vector4(0f, 0f, 0f, 1f) },
+                                    { nameof(abcBackColor), new Vector4(1f, 0.7f, 0f, 1f) },
+                                    { nameof(backCol), new Vector4(0.376f, 0.376f, 0.376f, 1f) },
+                                    { nameof(backColBorder), new Vector4(0f, 0f, 0f, 1f) },
+                                    { nameof(frontCol), new Vector4(0.9f, 0.9f, 0.9f, 1f) },
+                                    { nameof(ogcdCol), new Vector4(1f, 1f, 1f, 1f) },
+                                    { nameof(anLockCol), new Vector4(0.334f, 0.334f, 0.334f, 0.667f) },
+                                    { nameof(BarBackColBorder), new Vector4(0f, 0f, 0f, 1f) },
+                                    { nameof(slideCol), new Vector4(0f, 0f, 0f, 0.4f) },
+                                    { nameof(ctComboUsed), new Vector4(0.431f, 0.431f, 0.431f, 1f) },
+                                    { nameof(ctComboActive), new Vector4(1f, 1f, 1f, 1f) },
+                                    { nameof(BarBackCol), new Vector4(0.376f, 0.376f, 0.376f, 0.667f) },
+                                    { nameof(BarFrontCol), new Vector4(0.9f, 0.9f, 0.9f, 1f) },
+                                    { nameof(BarOgcdCol), new Vector4(1f, 1f, 1f, 1f) },
+                                    { nameof(BarAnLockCol), new Vector4(0.334f, 0.334f, 0.334f, 0.667f) },
+                                    { nameof(BarclipCol), new Vector4(1f, 0f, 0f, 0.667f) },
+                                    { nameof(CastBarTextColor), new Vector3(1f, 1f, 1f) },
+                                    { nameof(BarHasGradient), false },
+                                    { nameof(BarGradMode), 2 },
+                                    { nameof(BarBgGradMode), 3 },
+                                    { nameof(BarGradientMul), 0.175f },
+                                    { nameof(BarBgGradientMul), 0.175f },
+                                });
+                                showColorConfirmation = false;
+                                ImGui.CloseCurrentPopup();
+                            }
+                            ImGui.SameLine();
+                            if (ImGui.Button("Use DelvUI Inspired Colors")) {
+                                ResetColors(new Dictionary<string, object> {
+                                    { nameof(clipCol), new Vector4(0.9882353f, 0.32941177f, 0.0f, 0.6666667f) },
+                                    { nameof(abcCol), new Vector4(0.9882353f, 0.8235294f, 0.0f, 0.6666667f) },
+                                    { nameof(ClipTextColor), new Vector4(0.9f, 0.9f, 0.9f, 1.0f) },
+                                    { nameof(ClipBackColor), new Vector4(0.9882353f, 0.32941177f, 0.0f, 1.0f) },
+                                    { nameof(abcTextColor), new Vector4(0.0f, 0.0f, 0.0f, 1.0f) },
+                                    { nameof(abcBackColor), new Vector4(1.0f, 0.7f, 0.0f, 1.0f) },
+                                    { nameof(backCol), new Vector4(0.3764706f, 0.3764706f, 0.3764706f, 0.5019608f) },
+                                    { nameof(backColBorder), new Vector4(0.0f, 0.0f, 0.0f, 1.0f) },
+                                    { nameof(frontCol), new Vector4(0.0f, 0.63529414f, 0.9882353f, 1.0f) },
+                                    { nameof(ogcdCol), new Vector4(1.0f, 1.0f, 1.0f, 1.0f) },
+                                    { nameof(anLockCol), new Vector4(1.0f, 1.0f, 1.0f, 0.26666668f) },
+                                    { nameof(BarBackColBorder), new Vector4(0.0f, 0.0f, 0.0f, 1.0f) },
+                                    { nameof(slideCol), new Vector4(0.6745098f, 0.0f, 0.9882353f, 0.667f) },
+                                    { nameof(ctComboUsed), new Vector4(0.431f, 0.431f, 0.431f, 1.0f) },
+                                    { nameof(ctComboActive), new Vector4(1.0f, 1.0f, 1.0f, 1.0f) },
+                                    { nameof(BarBackCol), new Vector4(0.376f, 0.376f, 0.376f, 0.667f) },
+                                    { nameof(BarFrontCol), new Vector4(0.9f, 0.9f, 0.9f, 1.0f) },
+                                    { nameof(BarOgcdCol), new Vector4(1.0f, 1.0f, 1.0f, 1.0f) },
+                                    { nameof(BarAnLockCol), new Vector4(0.334f, 0.334f, 0.334f, 0.667f) },
+                                    { nameof(BarclipCol), new Vector4(1.0f, 0.0f, 0.0f, 0.667f) },
+                                    { nameof(CastBarTextColor), new Vector3(1.0f, 1.0f, 1.0f) },
+                                    { nameof(BarHasGradient), true },
+                                    { nameof(BarGradMode), 2 },
+                                    { nameof(BarBgGradMode), 1 },
+                                    { nameof(BarGradientMul), 0.2f },
+                                    { nameof(BarBgGradientMul), 0.2f },
+                                    { nameof(CastBarTextSize), 1.0f },
+                                    { nameof(CastBarTextOutlineEnabled), true },
+                                    { nameof(CastTimeEnabled), true },
+                                    { nameof(castTimePosition), 1 },
+                                    { nameof(OutlineThickness), 1.2f },
+                                    { nameof(CastBarBoldText), true }
+                                });
+                                showColorConfirmation = false;
+                                ImGui.CloseCurrentPopup();
+                            }
+                            ImGui.SameLine();
+                            if (ImGui.Button("Take Me Back")) {
+                                showColorConfirmation = false;
+                                ImGui.CloseCurrentPopup();
+                            }
+                            ImGui.EndPopup();
+                        }
                     }
                     ImGui.EndTabItem();
                 }
@@ -689,6 +776,22 @@ namespace GCDTracker
                         continue; // Skip resetting these fields
                     
                     field.SetValue(this, field.GetValue(defaultConfig));
+                }
+            }
+            Save();
+        }
+
+        public void ResetColors(Dictionary<string, object> fieldValues) {
+            foreach (var fieldEntry in fieldValues)
+            {
+                var field = typeof(Configuration).GetField(fieldEntry.Key);
+                if (field != null)
+                {
+                    field.SetValue(this, fieldEntry.Value);
+                }
+                else
+                {
+                    GCDTracker.Log.Warning($"Field '{fieldEntry.Key}' not found.");
                 }
             }
             Save();

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -626,13 +626,17 @@ namespace GCDTracker
                             ImGui.Text("If enabled, use Monospace font in GCDTracker.");
                             ImGui.EndTooltip();
                         }
+                        ImGui.NewLine();
                         ImGui.Checkbox("Pulse GCDBar Color @ Slide Lock", ref pulseBarColorAtSlide);
-
+                        ImGui.Checkbox("Pulse GCDBar Width @ Slide Lock", ref pulseBarWidthAtSlide);
                         ImGui.Checkbox("Pulse GCDBar Height @ Slide Lock", ref pulseBarHeightAtSlide);
+                        ImGui.NewLine();
                         ImGui.Checkbox("Pulse GCDBar Color @ Queue Lock", ref pulseBarColorAtQueue);
-
+                        ImGui.Checkbox("Pulse GCDBar Width @ Queue Lock", ref pulseBarWidthAtQueue);
                         ImGui.Checkbox("Pulse GCDBar Height @ Queue Lock", ref pulseBarHeightAtQueue);
+                        ImGui.NewLine();
                         ImGui.Checkbox("Pulse GCDWheel Size @ Queue Lock", ref pulseWheelAtQueue);
+                        ImGui.NewLine();
                         ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);
                         if (FloatingTrianglesEnable){
                             ImGui.Indent();

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -722,7 +722,7 @@ namespace GCDTracker
                                     { nameof(ClipBackColor), new Vector4(0.9882353f, 0.32941177f, 0.0f, 1.0f) },
                                     { nameof(abcTextColor), new Vector4(0.0f, 0.0f, 0.0f, 1.0f) },
                                     { nameof(abcBackColor), new Vector4(1.0f, 0.7f, 0.0f, 1.0f) },
-                                    { nameof(backCol), new Vector4(0.3764706f, 0.3764706f, 0.3764706f, 0.5019608f) },
+                                    { nameof(backCol), new Vector4(0.3764706f, 0.3764706f, 0.3764706f, 0.667f) },
                                     { nameof(backColBorder), new Vector4(0.0f, 0.0f, 0.0f, 1.0f) },
                                     { nameof(frontCol), new Vector4(0.0f, 0.63529414f, 0.9882353f, 1.0f) },
                                     { nameof(ogcdCol), new Vector4(1.0f, 1.0f, 1.0f, 1.0f) },

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -1,7 +1,6 @@
 ﻿using Dalamud.Configuration;
 using Dalamud.Interface;
 using Dalamud.Plugin;
-using FFXIVClientStructs.FFXIV.Client.UI;
 using GCDTracker.Data;
 using ImGuiNET;
 using Newtonsoft.Json;

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -62,6 +62,9 @@ namespace GCDTracker
         public bool BarEnabled = false;
         [JsonIgnore]
         public bool BarWindowMoveable = false;
+        public bool pulseBarColorAtSlide = false;
+        public bool pulseBarWidthAtSlide = false;
+        public bool pulseBarHeightAtSlide = false;
         public bool pulseBarColorAtQueue = false;
         public bool pulseBarWidthAtQueue = false;
         public bool pulseBarHeightAtQueue = false;
@@ -623,8 +626,11 @@ namespace GCDTracker
                             ImGui.Text("If enabled, use Monospace font in GCDTracker.");
                             ImGui.EndTooltip();
                         }
+                        ImGui.Checkbox("Pulse GCDBar Color @ Slide Lock", ref pulseBarColorAtSlide);
+
+                        ImGui.Checkbox("Pulse GCDBar Height @ Slide Lock", ref pulseBarHeightAtSlide);
                         ImGui.Checkbox("Pulse GCDBar Color @ Queue Lock", ref pulseBarColorAtQueue);
-                        ImGui.Checkbox("Pulse GCDBar Width @ Queue Lock", ref pulseBarWidthAtQueue);
+
                         ImGui.Checkbox("Pulse GCDBar Height @ Queue Lock", ref pulseBarHeightAtQueue);
                         ImGui.Checkbox("Pulse GCDWheel Size @ Queue Lock", ref pulseWheelAtQueue);
                         ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);

--- a/src/Configuration.cs
+++ b/src/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Configuration;
 using Dalamud.Interface;
 using Dalamud.Plugin;
+using FFXIVClientStructs.FFXIV.Client.UI;
 using GCDTracker.Data;
 using ImGuiNET;
 using Newtonsoft.Json;
@@ -111,6 +112,8 @@ namespace GCDTracker
 
         //Floating Triangles
         public bool FloatingTrianglesEnable = false;
+        public bool SlidecastTriangleEnable = true;
+        public bool QueuelockTriangleEnable = true;
         [JsonIgnore]
         public bool WindowMoveableSQI = false;
 
@@ -625,6 +628,12 @@ namespace GCDTracker
                         ImGui.Checkbox("Pulse GCDBar Height @ Queue Lock", ref pulseBarHeightAtQueue);
                         ImGui.Checkbox("Pulse GCDWheel Size @ Queue Lock", ref pulseWheelAtQueue);
                         ImGui.Checkbox("Draw Floating Triangles", ref FloatingTrianglesEnable);
+                        if (FloatingTrianglesEnable){
+                            ImGui.Indent();
+                            ImGui.Checkbox("Draw Slidecast Triangle", ref SlidecastTriangleEnable);
+                            ImGui.Checkbox("Draw Queuelock Triangle", ref QueuelockTriangleEnable);
+                            ImGui.Unindent();
+                        }
                         ImGui.Checkbox("Move/resize Triangles", ref WindowMoveableSQI);
                         if (WindowMoveableSQI)
                             ImGui.TextDisabled("\tWindow being edited, may ignore further visibility options.");

--- a/src/GCDDisplay.cs
+++ b/src/GCDDisplay.cs
@@ -300,5 +300,46 @@ namespace GCDTracker {
                 ui.DrawRightTriangle(ql_v.TR_C, ql_v.TR_X, ql_v.TR_Y, conf.backColBorder);
             }
         }
+
+public void DrawFloatingTriangles(PluginUI ui) {
+    float gcdTotal = DataStore.Action->TotalGCD;
+    float gcdElapsed = DataStore.Action->ElapsedGCD;
+    float gcdPercent = gcdElapsed / gcdTotal;
+    float castTotal = DataStore.Action->TotalCastTime;
+    float castElapsed = DataStore.Action->ElapsedCastTime;
+    float castPercent = castElapsed / castTotal;
+    float slidecastStart = (castTotal - 0.5f) / castTotal;
+    int triangleSize = (int)Math.Min(ui.w_size.X / 5, ui.w_size.Y / 5);
+    int borderOffset = (int)Math.Min(ui.w_size.X / 30, ui.w_size.Y / 30);
+    int halfTriangleSize = triangleSize / 2;
+    Vector4 red = new(1f, 0f, 0f, 1f);
+    Vector4 green = new(0f, 1f, 0f, 1f);
+    Vector4 bgCol = new(0f, 0f, 0f, 1f);
+
+    // slidecast
+    Vector2 slideTop = new(ui.w_cent.X - (int)(triangleSize / 1.5), ui.w_cent.Y - halfTriangleSize);
+    Vector2 slideLeft = slideTop + new Vector2(-triangleSize, triangleSize);
+    Vector2 slideRight = slideTop + new Vector2(triangleSize, triangleSize);
+    // queuelock
+    Vector2 queueBot = new(slideTop.X + (int)(1.5f * triangleSize), slideTop.Y + triangleSize);
+    Vector2 queueRight = queueBot - new Vector2(-triangleSize, triangleSize);
+    Vector2 queueLeft = queueBot - new Vector2(triangleSize, triangleSize);
+
+
+    Vector2 topLeft = slideTop - new Vector2(borderOffset, borderOffset);
+    Vector2 botLeft = slideLeft - new Vector2 (3 * borderOffset, -borderOffset);
+    Vector2 botRight = queueBot - new Vector2(-borderOffset, -borderOffset);
+    Vector2 topRight = queueRight - new Vector2(-(3 * borderOffset), borderOffset);
+
+    // Draw the parallelogram background
+    ui.DrawParallelogramFilledNoAA(topLeft, topRight, botRight, botLeft, bgCol);
+
+
+    Vector4 slideCol = castPercent != 0 && castPercent < slidecastStart ? red : green;
+    Vector4 queueCol = gcdPercent != 0 && gcdPercent < 0.8f ? red : green;
+
+    ui.DrawRightTriangle(slideTop, slideLeft, slideRight, slideCol);
+    ui.DrawRightTriangle(queueBot, queueRight, queueLeft, queueCol);
+}
     }
 }

--- a/src/GCDDisplay.cs
+++ b/src/GCDDisplay.cs
@@ -309,37 +309,42 @@ namespace GCDTracker {
             float castElapsed = DataStore.Action->ElapsedCastTime;
             float castPercent = castElapsed / castTotal;
             float slidecastStart = (castTotal - 0.5f) / castTotal;
-            int triangleSize = (int)Math.Min(ui.w_size.X / 5, ui.w_size.Y / 5);
-            int borderOffset = (int)Math.Min(ui.w_size.X / 30, ui.w_size.Y / 30);
-            int halfTriangleSize = triangleSize / 2;
+            int triangleSize = (int)Math.Min(ui.w_size.X / 3, ui.w_size.Y / 3);
+            int borderSize = triangleSize / 6;
             Vector4 red = new(1f, 0f, 0f, 1f);
             Vector4 green = new(0f, 1f, 0f, 1f);
-            Vector4 bgCol = new(0f, 0f, 0f, .8f);
+            Vector4 bgCol = new(0f, 0f, 0f, .6f);
 
             // slidecast
-            Vector2 slideTop = new(ui.w_cent.X - (int)(triangleSize / 1.5), ui.w_cent.Y - halfTriangleSize);
+            Vector2 slideTop = new(ui.w_cent.X, ui.w_cent.Y - triangleSize - borderSize);
             Vector2 slideLeft = slideTop + new Vector2(-triangleSize, triangleSize);
             Vector2 slideRight = slideTop + new Vector2(triangleSize, triangleSize);
             // queuelock
-            Vector2 queueBot = new(slideTop.X + (int)(1.5f * triangleSize), slideTop.Y + triangleSize);
+            Vector2 queueBot = new(slideTop.X,  ui.w_cent.Y + triangleSize + borderSize);
             Vector2 queueRight = queueBot - new Vector2(-triangleSize, triangleSize);
             Vector2 queueLeft = queueBot - new Vector2(triangleSize, triangleSize);
 
+            Vector2 slideBGTop = slideTop - new Vector2(0f, borderSize);
+            Vector2 slideBGLeft = slideLeft - new Vector2(1.75f * borderSize, - borderSize / 1.5f);
+            Vector2 slideBGRight = slideRight + new Vector2(1.75f * borderSize, borderSize / 1.5f);
 
-            Vector2 topLeft = slideTop - new Vector2(borderOffset / 2, borderOffset);
-            Vector2 botLeft = slideLeft - new Vector2 ((int)(2.5 * borderOffset), -borderOffset);
-            Vector2 botRight = queueBot - new Vector2(-(borderOffset / 2), -borderOffset);
-            Vector2 topRight = queueRight - new Vector2(-(int)(2.5f * borderOffset), borderOffset);
-
-            // Draw the parallelogram background
-            ui.DrawParallelogramFilledNoAA(topLeft, topRight, botRight, botLeft, bgCol);
+            // queuelock background
+            Vector2 queueBGBot = queueBot + new Vector2(0f, borderSize);
+            Vector2 queueBGRight = queueRight + new Vector2(1.75f * borderSize, - borderSize / 1.5f);
+            Vector2 queueBGLeft = queueLeft - new Vector2(1.75f * borderSize, borderSize / 1.5f);
 
 
             Vector4 slideCol = castPercent != 0 && castPercent < slidecastStart ? red : green;
             Vector4 queueCol = gcdPercent != 0 && gcdPercent < 0.8f ? red : green;
-
-            ui.DrawRightTriangle(slideTop, slideLeft, slideRight, slideCol);
-            ui.DrawRightTriangle(queueBot, queueRight, queueLeft, queueCol);
+            
+            if (conf.SlidecastTriangleEnable){
+                ui.DrawRightTriangle(slideBGTop, slideBGLeft, slideBGRight, bgCol);
+                ui.DrawRightTriangle(slideTop, slideLeft, slideRight, slideCol);
+            }
+            if (conf.QueuelockTriangleEnable){
+                ui.DrawRightTriangle(queueBGBot, queueBGRight, queueBGLeft, bgCol);
+                ui.DrawRightTriangle(queueBot, queueRight, queueLeft, queueCol);
+            }
         }
     }
 }

--- a/src/GCDDisplay.cs
+++ b/src/GCDDisplay.cs
@@ -164,12 +164,14 @@ namespace GCDTracker {
                 DataStore.ActionManager->CastActionType, 
                 DataStore.ClientState?.LocalPlayer?.TargetObject?.ObjectKind ?? ObjectKind.None
             );
+            var bar_v = BarVertices.Instance;
+            bar_v.Update(bar, go);
             var sc_sv = SlideCastStartVertices.Instance;
-            sc_sv.Update(bar, go);
+            sc_sv.Update(bar, bar_v, go);
             var sc_ev = SlideCastEndVertices.Instance;
-            sc_ev.Update(bar, go);
+            sc_ev.Update(bar, bar_v, go);
             var ql_v = QueueLockVertices.Instance;
-            ql_v.Update (bar, go); 
+            ql_v.Update (bar, bar_v, go); 
 
             float barGCDClipTime = 0;
             
@@ -177,13 +179,15 @@ namespace GCDTracker {
             // draw the background
             if (bar.CurrentPos < 0.2f)
                 bgCache = helper.BackgroundColor();
-            ui.DrawRectFilledNoAA(bar.StartVertex, bar.EndVertex, bgCache, conf.BarBgGradMode, conf.BarBgGradientMul);
+            ui.DrawRectFilledNoAA(bar_v.StartVertex, bar_v.EndVertex, bgCache, conf.BarBgGradMode, conf.BarBgGradientMul);
 
             // in both modes:
             // draw cast/gcd progress (main) bar
-            if(bar.CurrentPos > 0.001f)
-                ui.DrawRectFilledNoAA(bar.StartVertex, bar.ProgressVertex, bar.ProgressBarColor, conf.BarGradMode, conf.BarGradientMul);
             
+            if(bar.CurrentPos > 0.001f){
+                var progressBarColor = go.Allow_Bar_Pulse ? bar.ProgressPulseColor : bar.ProgressBarColor;
+                ui.DrawRectFilledNoAA(bar_v.StartVertex, bar_v.ProgressVertex, progressBarColor, conf.BarGradMode, conf.BarGradientMul);
+            }
             // in Castbar mode:
             // draw the slidecast bar
             if (conf.SlideCastEnabled)
@@ -208,32 +212,32 @@ namespace GCDTracker {
                         if (!helper.isHardCast) {
                             // create end vertex
                             Vector2 clipEndVector = new(
-                                (int)(bar.CenterX + ((barGCDClipTime / gcdTotal) * bar.Width) - bar.HalfWidth),
-                                (int)(bar.CenterY + bar.HalfHeight)
+                                (int)(bar.CenterX + ((barGCDClipTime / gcdTotal) * bar_v.Width) - bar_v.HalfWidth),
+                                (int)(bar.CenterY + bar_v.HalfHeight)
                             );
                             // Draw the clipped part at the beginning
-                            ui.DrawRectFilledNoAA(bar.StartVertex, clipEndVector, conf.clipCol);
+                            ui.DrawRectFilledNoAA(bar_v.StartVertex, clipEndVector, conf.clipCol);
                         }
                     }
 
                     Vector2 oGCDStartVector = new(
-                        (int)(bar.CenterX + ((ogcdStart / gcdTotal) * bar.Width) - bar.RawHalfWidth),
-                        (int)(bar.CenterY - bar.RawHalfHeight)
+                        (int)(bar.CenterX + ((ogcdStart / gcdTotal) * bar_v.Width) - bar_v.RawHalfWidth),
+                        (int)(bar.CenterY - bar_v.RawHalfHeight)
                     );
                     Vector2 oGCDEndVector = new(
-                        (int)(bar.CenterX + ((ogcdEnd / gcdTotal) * bar.Width) - bar.HalfWidth),
-                        (int)(bar.CenterY + bar.HalfHeight)
+                        (int)(bar.CenterX + ((ogcdEnd / gcdTotal) * bar_v.Width) - bar_v.HalfWidth),
+                        (int)(bar.CenterY + bar_v.HalfHeight)
                     );
 
                     if(!helper.shortCastFinished || isClipping) {
                         ui.DrawRectFilledNoAA(oGCDStartVector, oGCDEndVector, isClipping ? conf.clipCol : conf.anLockCol);
                         if (!iscast && (!isClipping || ogcdStart > 0.01f)) {
                             Vector2 clipPos = new(
-                                bar.CenterX + (ogcdStart / gcdTotal * bar.Width) - bar.RawHalfWidth,
-                                bar.CenterY - bar.RawHalfHeight + 1f
+                                bar.CenterX + (ogcdStart / gcdTotal * bar_v.Width) - bar_v.RawHalfWidth,
+                                bar.CenterY - bar_v.RawHalfHeight + 1f
                             );
                             ui.DrawRectFilledNoAA(clipPos,
-                                clipPos + new Vector2(2f * ui.Scale, bar.Height - 2f),
+                                clipPos + new Vector2(2f * ui.Scale, bar_v.Height - 2f),
                                 conf.ogcdCol);
                     }
                     }
@@ -249,8 +253,8 @@ namespace GCDTracker {
             // draw borders
             if (bar.BorderSize > 0) {
                 ui.DrawRect(
-                    bar.StartVertex - new Vector2(bar.HalfBorderSize, bar.HalfBorderSize),
-                    bar.EndVertex + new Vector2(bar.HalfBorderSize, bar.HalfBorderSize),
+                    bar_v.StartVertex - new Vector2(bar.HalfBorderSize, bar.HalfBorderSize),
+                    bar_v.EndVertex + new Vector2(bar.HalfBorderSize, bar.HalfBorderSize),
                     conf.backColBorder, bar.BorderSize);
             }
         }

--- a/src/GCDHelper.cs
+++ b/src/GCDHelper.cs
@@ -488,6 +488,31 @@ namespace GCDTracker {
                 bg = conf.abcCol;
             return bg;
         }
+        public float GetWheelScale(float uiScale) {
+            float wheelPos = lastElapsedGCD / TotalGCD;
+            if (wheelPos <= 0.78f || !conf.pulseWheelAtQueue)
+                return uiScale;
+            float targetScale = uiScale * 1.6f;
+
+            if (wheelPos < 0.82f) {
+                float factor = (wheelPos - 0.78f) / 0.04f;
+                return Lerp(uiScale, targetScale, factor);
+            }
+            else if (wheelPos < 0.86f) {
+                return targetScale;
+            }
+            else if (wheelPos < 0.9f) {
+                float factor = (wheelPos - 0.86f) / 0.04f;
+                return Lerp(targetScale, uiScale, factor);
+            }
+            else {
+                return uiScale;
+            }
+        }
+
+        private float Lerp(float start, float end, float factor) {
+            return start + factor * (end - start);
+        }
 
         public bool CheckClip(bool iscast, float ogcd, float anlock, float gcdTotal, float gcdTime) =>
             !iscast && !isHardCast && DateTime.Now > lastGCDEnd + TimeSpan.FromMilliseconds(50)  &&

--- a/src/GCDHelper.cs
+++ b/src/GCDHelper.cs
@@ -42,6 +42,7 @@ namespace GCDTracker {
         public bool SlideStart_RightTri { get; private set; }
         public bool SlideEnd_RightTri { get; private set; }
         public bool Slide_Background { get; private set; }
+        public bool Allow_Bar_Pulse { get; private set;}
         public float Queue_Lock_Start { get; private set; }
         public float Slide_Bar_Start { get; private set; }
         public float Slide_Bar_End { get; private set; }
@@ -94,19 +95,19 @@ namespace GCDTracker {
                         };
                     }
                     else if (bar.IsShortCast) {
-                        Queue_Lock_Start = 0.8f;
+                        Queue_Lock_Start = bar.QueueLockStart;
                         if (Math.Abs(Slide_Bar_End - Queue_Lock_Start) < epsilon)
                             Slide_Bar_End = Queue_Lock_Start;
                         currentState = BarState.ShortCast;
                     }
                     else if (!bar.IsShortCast) {
-                        Queue_Lock_Start = 0.8f * (bar.GCDTotal / bar.CastTotal);
+                        Queue_Lock_Start = bar.QueueLockStart;
                         currentState = BarState.LongCast;
                     }
                 }
                 // Handle GCDBar
                 else if (!bar.IsCastBar && !bar.IsShortCast) {
-                    Queue_Lock_Start = 0.8f;
+                    Queue_Lock_Start = bar.QueueLockStart;
                     currentState = BarState.GCDOnly;
                 }
             }
@@ -154,6 +155,9 @@ namespace GCDTracker {
         }
 
         private void HandleGCDOnly(BarInfo bar, Configuration conf) {
+            // enable pulse
+            Allow_Bar_Pulse = true;
+            
             // draw line
             Queue_VerticalBar = true;      
 
@@ -194,6 +198,9 @@ namespace GCDTracker {
         }
 
         private void HandleCastBarShort(BarInfo bar, Configuration conf) {
+            // enable pulse
+            Allow_Bar_Pulse = true;
+            
             // draw lines
             SlideStart_VerticalBar = true;
             SlideEnd_VerticalBar = !conf.SlideCastFullBar;
@@ -216,7 +223,10 @@ namespace GCDTracker {
         }
 
         private void HandleCastBarLong(BarInfo bar, Configuration conf) {
-            //draw line
+            // enable pulse
+            Allow_Bar_Pulse = true;
+            
+            // draw line
             SlideStart_VerticalBar = true;
             
             // draw triangles
@@ -250,6 +260,7 @@ namespace GCDTracker {
             SlideStart_RightTri = false;
             SlideEnd_RightTri = false;
             Slide_Background = false;
+            Allow_Bar_Pulse = false;
         }
     }
 
@@ -488,6 +499,7 @@ namespace GCDTracker {
                 bg = conf.abcCol;
             return bg;
         }
+        
         public float GetWheelScale(float uiScale) {
             float wheelPos = lastElapsedGCD / TotalGCD;
             if (wheelPos <= 0.78f || !conf.pulseWheelAtQueue)

--- a/src/GCDNotifier.cs
+++ b/src/GCDNotifier.cs
@@ -1,0 +1,304 @@
+using GCDTracker.UI;
+using System.Collections.Generic;
+using Dalamud.Interface.Animation;
+using Dalamud.Interface.Animation.EasingFunctions;
+using System.Numerics;
+using System.Linq;
+using System;
+
+namespace GCDTracker {
+
+    public enum EventType {
+        FlyOutAlert,
+        BarColorPulse,
+        BarWidthPulse,
+        BarHeightPulse,
+        BarBackground,
+        WheelPulse,
+        FloatingTriangle,
+        None
+    }
+
+    public enum EventCause {
+        Slidecast,
+        Queuelock,
+        Clipped,
+        ABC,
+        None
+    }
+
+    public class Alert
+    {
+        public EventType Type { get; set; }
+        public EventCause Reason { get; set; }
+        public float LocationX { get; set; }
+        public float LocationY { get; set; }
+        public float LastClipDelta { get; set; }
+
+        public Alert(EventType type, EventCause reason, float lastClipDelta, float locationX, float locationY)
+        {
+            Type = type;
+            Reason = reason;
+            LocationX = locationX;
+            LocationY = locationY;
+            LastClipDelta = lastClipDelta;
+        }
+    }
+
+    public class AlertManager
+    {
+        private static AlertManager instance;
+        private readonly Queue<Alert> alertQueue = new Queue<Alert>();
+        private AlertManager() { }
+
+        public static AlertManager Instance => instance ??= new AlertManager();
+
+        public int AlertCount => alertQueue.Count;
+
+        public void AddAlert(EventType type, EventCause reason, float locationX = 0f, float locationY = 0f, float lastClipDelta = 0f) {
+            alertQueue.Enqueue(new Alert(type, reason, locationX, locationY, lastClipDelta));
+        }
+
+        public Alert PeekAlert() => alertQueue.Count > 0 ? alertQueue.Peek() : null;
+
+        public void DequeueAlert() {
+            if (alertQueue.Count > 0) {
+                alertQueue.Dequeue();
+            }
+        }
+
+        public void ClearAlerts() => alertQueue.Clear();
+
+        public bool AlertExists(EventType type, EventCause reason) {
+            return alertQueue.Any(alert => alert.Type == type && alert.Reason == reason);
+        }
+    }
+
+    public class GCDEventHandler {
+        private static GCDEventHandler instance;
+
+        private const float TransitionDuration = 300f;
+        private const float FirstStageEnd = 100f;
+        private const float SecondStageEnd = 200f;
+
+        public int PulseWidth { get; private set; }
+        public int PulseHeight { get; private set; }
+        public Vector4 ProgressPulseColor { get; private set; }
+        public float WheelScale { get; private set; }
+        private EventCause FlyOutCause;
+        private bool BarColor;
+        private EventCause BarColorCause;
+        private bool BarWidth;
+        private EventType BarWidthType;
+        private bool BarHeight;
+        private EventType BarHeightType;
+        private bool wheelPulse;
+        private DateTime colorStartTime = DateTime.MinValue;
+        private DateTime widthStartTime = DateTime.MinValue;
+        private DateTime heightStartTime = DateTime.MinValue;
+        private DateTime wheelStartTime = DateTime.MinValue;
+
+        public readonly Easing alertAnimEnabled;
+        public readonly Easing alertAnimPos;
+        public readonly string[] alertText;
+
+        private GCDEventHandler() {
+            alertAnimEnabled = new OutCubic(new(0, 0, 0, 2, 1000)) {
+                Point1 = new(0.25f, 0),
+                Point2 = new(1f, 0)
+            };
+            alertAnimPos = new OutCubic(new(0, 0, 0, 1, 500)) {
+                Point1 = new(0, 0),
+                Point2 = new(0, -20)
+            };
+            alertText = ["CLIP", "0.0", "0.00", "A-B-C"];
+        }
+
+        public static GCDEventHandler Instance => instance ??= new GCDEventHandler();
+
+        public void StartAlert(bool isClip, float ms) {
+            if (isClip) {
+                alertText[1] = string.Format("{0:0.0}", ms);
+                alertText[2] = string.Format("{0:0.00}", ms);
+            }
+            alertAnimEnabled.Restart();
+            alertAnimPos.Restart();
+        }
+
+        public void Update(BarInfo bar, Configuration conf, PluginUI ui) {
+            int alertCount = AlertManager.Instance.AlertCount;
+
+            for (int i = 0; i < alertCount; i++) {
+                var alert = AlertManager.Instance.PeekAlert();
+                if (alert == null) continue;
+                HandleAlert(alert);
+                AlertManager.Instance.DequeueAlert();
+            }
+
+            if (bar != null) {    
+                UpdateBarProperties(bar, conf);
+                UpdateFlyOut(ui, conf, FlyOutCause, (conf.BarWidthRatio + 1) / 2.1f, -0.3f);
+            }
+            else {
+                UpdateWheelProperties(ui.Scale);
+                UpdateFlyOut(ui, conf, FlyOutCause, 0.5f, 0f);
+            }
+        }
+
+        private void HandleAlert(Alert alert) {
+            switch (alert.Type) {
+                case EventType.FlyOutAlert:
+                    FlyOutCause = alert.Reason;
+                    FlyOutAlert(alert.LastClipDelta);
+                    break;
+
+                case EventType.BarColorPulse when !BarColor:
+                    BarColor = true;
+                    BarColorCause = alert.Reason;
+                    break;
+
+                case EventType.BarWidthPulse when !BarWidth:
+                    BarWidth = true;
+                    BarWidthType = alert.Type;
+                    break;
+
+                case EventType.BarHeightPulse when !BarHeight:
+                    BarHeight = true;
+                    BarHeightType = alert.Type;
+                    break;
+
+                case EventType.WheelPulse when !wheelPulse:
+                    wheelPulse = true;
+                    break;
+            }
+        }
+
+        private void UpdateBarProperties(BarInfo bar, Configuration conf) {
+            ProgressPulseColor = GetBarColor(conf.frontCol, conf.slideCol, BarColorCause, BarColor);
+            PulseWidth = GetBarSize(bar.Width, BarWidthType, BarWidth, ref widthStartTime);
+            PulseHeight = GetBarSize(bar.Height, BarHeightType, BarHeight, ref heightStartTime);
+        }
+
+        private void UpdateWheelProperties(float uiScale) {
+            WheelScale = GetWheelScale(uiScale, wheelPulse);
+        }
+
+        private void UpdateFlyOut(PluginUI ui, Configuration conf, EventCause reason, float relx, float rely) {
+            switch (reason) {
+                case EventCause.Clipped:
+                    ui.DrawAlert(relx, rely, conf.ClipTextSize, conf.ClipTextColor, conf.ClipBackColor, conf.ClipAlertPrecision);
+                    break;
+                
+                case EventCause.ABC:
+                    ui.DrawAlert(relx, rely, conf.abcTextSize, conf.abcTextColor, conf.abcBackColor, 3);
+                    break;
+            }
+        }
+
+        private void FlyOutAlert(float lastClipDelta) {
+            switch (FlyOutCause) {
+                case EventCause.Clipped:
+                    StartAlert(true, lastClipDelta);
+                    break;
+                case EventCause.ABC:
+                    StartAlert(false, lastClipDelta);
+                    break;
+            }
+        }
+
+        private Vector4 GetBarColor(Vector4 progressBarColor, Vector4 slideCol, EventCause reason, bool enable) {
+            Vector4 targetColor = reason switch {
+                EventCause.Queuelock => CalculateTargetColor(progressBarColor),
+                EventCause.Slidecast => new Vector4(slideCol.X, slideCol.Y, slideCol.Z, progressBarColor.W),
+                _ => progressBarColor
+            };
+
+            if (colorStartTime == DateTime.MinValue && enable) {
+                colorStartTime = DateTime.Now;
+            }
+
+            return ApplyColorTransition(progressBarColor, targetColor, enable, ref BarColor, ref BarColorCause, ref colorStartTime);
+
+            static Vector4 CalculateTargetColor(Vector4 color) {
+                return (color.X * 0.3f + color.Y * 0.6f + color.Z * 0.2f) > 0.7f 
+                    ? new Vector4(0f, 0f, 0f, color.W) 
+                    : new Vector4(1f, 1f, 1f, color.W);
+            }
+        }
+
+        private int GetBarSize(int dimension, EventType type, bool enable, ref DateTime startTime) {
+            int offset = type switch {
+                EventType.BarWidthPulse => 10,
+                EventType.BarHeightPulse => 5,
+                _ => 0
+            };
+
+            if (startTime == DateTime.MinValue && enable) {
+                startTime = DateTime.Now;
+            }
+
+            return ApplySizeTransition(dimension, offset, enable, ref type == EventType.BarWidthPulse ? ref BarWidth : ref BarHeight, ref type == EventType.BarWidthPulse ? ref BarWidthType : ref BarHeightType, ref startTime);
+        }
+
+        private Vector4 ApplyColorTransition(Vector4 startColor, Vector4 targetColor, bool enable, ref bool transitionActive, ref EventCause transitionCause, ref DateTime startTime) {
+            float elapsedTime = (float)(DateTime.Now - startTime).TotalMilliseconds;
+
+            if (!enable || elapsedTime >= TransitionDuration) {
+                transitionActive = false;
+                transitionCause = EventCause.None;
+                startTime = DateTime.MinValue;
+                return startColor;
+            }
+
+            return elapsedTime switch {
+                < FirstStageEnd => Vector4.Lerp(startColor, targetColor, elapsedTime / FirstStageEnd),
+                < SecondStageEnd => targetColor,
+                _ => Vector4.Lerp(targetColor, startColor, (elapsedTime - SecondStageEnd) / (TransitionDuration - SecondStageEnd))
+            };
+        }
+
+        private int ApplySizeTransition(int startDimension, int offset, bool enable, ref bool transitionActive, ref EventType transitionType, ref DateTime startTime) {
+            float elapsedTime = (float)(DateTime.Now - startTime).TotalMilliseconds;
+
+            if (!enable || elapsedTime >= TransitionDuration) {
+                transitionActive = false;
+                transitionType = EventType.None;
+                startTime = DateTime.MinValue;
+                return startDimension;
+            }
+
+            int targetDimension = startDimension + offset;
+
+            return (int)(elapsedTime switch {
+                < FirstStageEnd => Lerp(startDimension, targetDimension, elapsedTime / FirstStageEnd),
+                < SecondStageEnd => targetDimension,
+                _ => Lerp(targetDimension, startDimension, (elapsedTime - SecondStageEnd) / (TransitionDuration - SecondStageEnd))
+            });
+        }
+
+        public float GetWheelScale(float uiScale, bool enable) {
+            if (enable && wheelStartTime == DateTime.MinValue) {
+                wheelStartTime = DateTime.Now;
+            }
+
+            float elapsedTime = (float)(DateTime.Now - wheelStartTime).TotalMilliseconds;
+            float targetScale = uiScale * 1.6f;
+
+            return elapsedTime switch {
+                < FirstStageEnd => Lerp(uiScale, targetScale, elapsedTime / FirstStageEnd),
+                < SecondStageEnd => targetScale,
+                < TransitionDuration => Lerp(targetScale, uiScale, (elapsedTime - SecondStageEnd) / (TransitionDuration - SecondStageEnd)),
+                _ => ResetWheel(uiScale)
+            };
+        }
+
+        private float ResetWheel(float uiScale) {
+            wheelPulse = false;
+            wheelStartTime = DateTime.MinValue;
+            return uiScale;
+        }
+
+        static float Lerp(float a, float b, float t) => a + (b - a) * t;
+        
+    }
+}

--- a/src/UI/BarHelpers.cs
+++ b/src/UI/BarHelpers.cs
@@ -112,6 +112,11 @@ namespace GCDTracker.UI {
                     conf.slideCol,
                     IsCastBar);
             }
+            else {
+                PulseWidth = Width;
+                PulseHeight = Height;
+                ProgressPulseColor = conf.frontCol;
+            }
         }
 
         private Vector4 GetBarColor(

--- a/src/UI/BarHelpers.cs
+++ b/src/UI/BarHelpers.cs
@@ -89,6 +89,7 @@ namespace GCDTracker.UI {
                     conf.pulseBarWidthAtQueue, 
                     conf.pulseBarWidthAtSlide,
                     IsCastBar,
+                    true,
                     QueueLockScaleFactorCache);
                 PulseHeight = GetBarSize(
                     Height, 
@@ -98,6 +99,7 @@ namespace GCDTracker.UI {
                     conf.pulseBarHeightAtQueue, 
                     conf.pulseBarHeightAtSlide,
                     IsCastBar,
+                    false,
                     QueueLockScaleFactorCache);
                 ProgressPulseColor = GetBarColor(
                     conf.frontCol, 
@@ -168,11 +170,12 @@ namespace GCDTracker.UI {
             float slidecastStart, 
             bool pulseAtQueue, 
             bool pulseAtSlide, 
-            bool IsCastbar, 
+            bool IsCastbar,
+            bool isWidth,
             float scaleFactor) {
 
             int CalculateSize(int originalSize, float eventStart, float scaleFactor) {
-                int targetDimension = (int)(originalSize * 1.2f);
+                int targetDimension = (int)(originalSize * (isWidth ? 1.05f : 1.2f));
 
                 if (currentPos < eventStart + 0.02f * scaleFactor) {
                     float factor = (currentPos - eventStart + 0.02f * scaleFactor) / (0.04f * scaleFactor);

--- a/src/UI/BarHelpers.cs
+++ b/src/UI/BarHelpers.cs
@@ -175,7 +175,7 @@ namespace GCDTracker.UI {
             float scaleFactor) {
 
             int CalculateSize(int originalSize, float eventStart, float scaleFactor) {
-                int targetDimension = (int)(originalSize * (isWidth ? 1.05f : 1.2f));
+                int targetDimension = originalSize + (isWidth ? 10 : 5);
 
                 if (currentPos < eventStart + 0.02f * scaleFactor) {
                     float factor = (currentPos - eventStart + 0.02f * scaleFactor) / (0.04f * scaleFactor);

--- a/src/UI/BarHelpers.cs
+++ b/src/UI/BarHelpers.cs
@@ -132,16 +132,16 @@ namespace GCDTracker.UI {
             }
 
             Vector4 ApplyColorTransition(Vector4 currentColor, float eventStart, Vector4 targetColor) {
-                if (currentPos > eventStart - 0.02f * scaleFactor) {
-                    if (currentPos < eventStart + 0.02f * scaleFactor) {
-                        float factor = (currentPos - eventStart + 0.02f * scaleFactor) / (0.04f * scaleFactor);
+                if (currentPos > eventStart - 0.025f * scaleFactor) {
+                    if (currentPos < eventStart + 0.025f * scaleFactor) {
+                        float factor = (currentPos - eventStart + 0.025f * scaleFactor) / (0.05f * scaleFactor);
                         return Vector4.Lerp(currentColor, targetColor, factor);
                     } 
-                    else if (currentPos < eventStart + 0.06f * scaleFactor) {
+                    else if (currentPos < eventStart + 0.075f * scaleFactor) {
                         return targetColor;
                     } 
-                    else if (currentPos < eventStart + 0.1f * scaleFactor) {
-                        float factor = (currentPos - eventStart - 0.06f * scaleFactor) / (0.04f * scaleFactor);
+                    else if (currentPos < eventStart + 0.125f * scaleFactor) {
+                        float factor = (currentPos - eventStart - 0.075f * scaleFactor) / (0.05f * scaleFactor);
                         return Vector4.Lerp(targetColor, currentColor, factor);
                     }
                 }
@@ -177,15 +177,15 @@ namespace GCDTracker.UI {
             int CalculateSize(int originalSize, float eventStart, float scaleFactor) {
                 int targetDimension = originalSize + (isWidth ? 10 : 5);
 
-                if (currentPos < eventStart + 0.02f * scaleFactor) {
-                    float factor = (currentPos - eventStart + 0.02f * scaleFactor) / (0.04f * scaleFactor);
+                if (currentPos < eventStart + 0.025f * scaleFactor) {
+                    float factor = (currentPos - eventStart + 0.025f * scaleFactor) / (0.05f * scaleFactor);
                     return (int)Lerp(originalSize, targetDimension, factor);
                 } 
-                else if (currentPos < eventStart + 0.06f * scaleFactor) {
+                else if (currentPos < eventStart + 0.075f * scaleFactor) {
                     return targetDimension;
                 } 
-                else if (currentPos < eventStart + 0.1f * scaleFactor) {
-                    float factor = (currentPos - eventStart - 0.06f * scaleFactor) / (0.04f * scaleFactor);
+                else if (currentPos < eventStart + 0.125f * scaleFactor) {
+                    float factor = (currentPos - eventStart - 0.075f * scaleFactor) / (0.05f * scaleFactor);
                     return (int)Lerp(targetDimension, originalSize, factor);
                 } 
                 else {

--- a/src/UI/BarHelpers.cs
+++ b/src/UI/BarHelpers.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Numerics;
 using GCDTracker.Data;
-using Lumina.Excel.GeneratedSheets;
 
 namespace GCDTracker.UI {
     public unsafe class BarInfo {
@@ -10,8 +9,6 @@ namespace GCDTracker.UI {
         public float CenterY { get; private set; }
         public int Width { get; private set; }
         public int Height { get; private set; }
-        public int PulseWidth { get; private set; }
-        public int PulseHeight { get; private set; }
         public int BorderSize { get; private set; }
         public int HalfBorderSize { get; private set; }
         public int BorderSizeAdj { get; private set; }
@@ -23,13 +20,11 @@ namespace GCDTracker.UI {
         public float CastTotal { get; private set; }
         public float QueueLockStart { get; private set; }
         public float QueueLockScaleFactor { get; private set; }
-        public float QueueLockScaleFactorCache { get; private set; }
         public int TriangleOffset { get; private set; }
         public bool IsCastBar { get; private set; }
         public bool IsShortCast { get; private set; }
         public bool IsNonAbility { get; private set; }
         public Vector4 ProgressBarColor { get; private set; }
-        public Vector4 ProgressPulseColor { get; private set; }
 
         private BarInfo() { }
         public static BarInfo Instance {
@@ -77,144 +72,7 @@ namespace GCDTracker.UI {
             TriangleOffset = triangleOffset;
             ProgressBarColor = conf.frontCol;
 
-
-            if (conf.pulseBarColorAtQueue || conf.pulseBarWidthAtQueue || conf.pulseBarHeightAtQueue || conf.pulseBarColorAtSlide) {
-                if (CurrentPos < 0.02f)
-                    QueueLockScaleFactorCache = QueueLockScaleFactor;
-                PulseWidth = GetBarSize(
-                    Width, 
-                    CurrentPos, 
-                    QueueLockStart, 
-                    GCDTime_SlidecastStart,
-                    conf.pulseBarWidthAtQueue, 
-                    conf.pulseBarWidthAtSlide,
-                    IsCastBar,
-                    true,
-                    QueueLockScaleFactorCache);
-                PulseHeight = GetBarSize(
-                    Height, 
-                    CurrentPos, 
-                    QueueLockStart, 
-                    GCDTime_SlidecastStart,
-                    conf.pulseBarHeightAtQueue, 
-                    conf.pulseBarHeightAtSlide,
-                    IsCastBar,
-                    false,
-                    QueueLockScaleFactorCache);
-                ProgressPulseColor = GetBarColor(
-                    conf.frontCol, 
-                    CurrentPos, 
-                    QueueLockStart,
-                    GCDTime_SlidecastStart,
-                    conf.pulseBarColorAtQueue,
-                    conf.pulseBarColorAtSlide,
-                    QueueLockScaleFactorCache,
-                    conf.slideCol,
-                    IsCastBar);
-            }
-            else {
-                PulseWidth = Width;
-                PulseHeight = Height;
-                ProgressPulseColor = conf.frontCol;
-            }
         }
-
-        private Vector4 GetBarColor(
-            Vector4 progressBarColor, 
-            float currentPos, 
-            float queueLockStart, 
-            float slidecastStart, 
-            bool pulseBarColorAtQueue, 
-            bool pulseBarColorAtSlide, 
-            float scaleFactor, 
-            Vector4 slideCol, 
-            bool IsCastbar) {
-
-            Vector4 CalculateTargetColor(Vector4 color) {
-                return (color.X * 0.3f + color.Y * 0.6f + color.Z * 0.2f) > 0.7f 
-                    ? new Vector4(0f, 0f, 0f, color.W) 
-                    : new Vector4(1f, 1f, 1f, color.W);
-            }
-
-            Vector4 ApplyColorTransition(Vector4 currentColor, float eventStart, Vector4 targetColor) {
-                if (currentPos > eventStart - 0.025f * scaleFactor) {
-                    if (currentPos < eventStart + 0.025f * scaleFactor) {
-                        float factor = (currentPos - eventStart + 0.025f * scaleFactor) / (0.05f * scaleFactor);
-                        return Vector4.Lerp(currentColor, targetColor, factor);
-                    } 
-                    else if (currentPos < eventStart + 0.075f * scaleFactor) {
-                        return targetColor;
-                    } 
-                    else if (currentPos < eventStart + 0.125f * scaleFactor) {
-                        float factor = (currentPos - eventStart - 0.075f * scaleFactor) / (0.05f * scaleFactor);
-                        return Vector4.Lerp(targetColor, currentColor, factor);
-                    }
-                }
-                return currentColor;
-            }
-
-            Vector4 resultColor = progressBarColor;
-
-            if (pulseBarColorAtQueue) {
-                Vector4 queueLockTargetColor = CalculateTargetColor(progressBarColor);
-                resultColor = ApplyColorTransition(resultColor, queueLockStart, queueLockTargetColor);
-            }
-
-            if (IsCastbar && pulseBarColorAtSlide) {
-                Vector4 slidecastTargetColor = new Vector4(slideCol.X, slideCol.Y, slideCol.Z, progressBarColor.W);
-                resultColor = ApplyColorTransition(resultColor, slidecastStart, slidecastTargetColor);
-            }
-
-            return resultColor;
-        }
-
-        private int GetBarSize(
-            int dimension, 
-            float currentPos, 
-            float queueLockStart, 
-            float slidecastStart, 
-            bool pulseAtQueue, 
-            bool pulseAtSlide, 
-            bool IsCastbar,
-            bool isWidth,
-            float scaleFactor) {
-
-            int CalculateSize(int originalSize, float eventStart, float scaleFactor) {
-                int targetDimension = originalSize + (isWidth ? 10 : 5);
-
-                if (currentPos < eventStart + 0.025f * scaleFactor) {
-                    float factor = (currentPos - eventStart + 0.025f * scaleFactor) / (0.05f * scaleFactor);
-                    return (int)Lerp(originalSize, targetDimension, factor);
-                } 
-                else if (currentPos < eventStart + 0.075f * scaleFactor) {
-                    return targetDimension;
-                } 
-                else if (currentPos < eventStart + 0.125f * scaleFactor) {
-                    float factor = (currentPos - eventStart - 0.075f * scaleFactor) / (0.05f * scaleFactor);
-                    return (int)Lerp(targetDimension, originalSize, factor);
-                } 
-                else {
-                    return originalSize;
-                }
-            }
-
-            float Lerp(float a, float b, float t) {
-                return a + (b - a) * t;
-            }
-
-            int resultSize = dimension;
-
-            if (pulseAtQueue && currentPos > queueLockStart - 0.02f * scaleFactor) {
-                resultSize = CalculateSize(dimension, queueLockStart, scaleFactor);
-            }
-
-            if (IsCastbar && pulseAtSlide && currentPos > slidecastStart - 0.02f * scaleFactor) {
-                resultSize = CalculateSize(resultSize, slidecastStart, scaleFactor);
-            }
-
-            return resultSize;
-        }
-
     }
 
     public class BarVertices {
@@ -239,11 +97,11 @@ namespace GCDTracker.UI {
             }
         }
 
-        public void Update(BarInfo bar, BarDecisionHelper go) {
-            Width = go.Allow_Bar_Pulse ? bar.PulseWidth : bar.Width;
+        public void Update(BarInfo bar, BarDecisionHelper go, GCDEventHandler notify) {
+            Width = notify.PulseWidth;
             HalfWidth = Width % 2 == 0 ? (Width / 2) : (Width / 2) + 1;
             RawHalfWidth = Width / 2;
-            Height = go.Allow_Bar_Pulse ? bar.PulseHeight : bar.Height;
+            Height = notify.PulseHeight;
             HalfHeight = Height % 2 == 0 ? (Height / 2) : (Height / 2) + 1;
             RawHalfHeight = Height / 2;
             BorderWidthPercent = (float)bar.BorderSizeAdj / (float)bar.Width;

--- a/src/UI/PluginUI.cs
+++ b/src/UI/PluginUI.cs
@@ -113,6 +113,14 @@ namespace GCDTracker.UI {
                 ct.DrawComboLines(this, conf);
                 ImGui.End();
             }
+
+            if (conf.FloatingTrianglesEnable) {
+                SetupWindow("GCDTracker_SlideQueueIndicators", conf.WindowMoveableSQI);
+                gcd.DrawFloatingTriangles(this);
+                ImGui.End();
+            }
+
+
         }
 
         private void SetupWindow(string name,bool windowMovable) {
@@ -346,6 +354,15 @@ namespace GCDTracker.UI {
                     ImGui.GetColorU32(lineColor)
                 );
             }
+
+            draw.Flags = originalFlags;
+        }
+
+        public void DrawParallelogramFilledNoAA(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector4 color) {
+            var originalFlags = draw.Flags;
+            draw.Flags &= ~ImDrawListFlags.AntiAliasedFill;
+
+            draw.AddQuadFilled(p1, p2, p3, p4, ImGui.GetColorU32(color));
 
             draw.Flags = originalFlags;
         }

--- a/src/UI/PluginUI.cs
+++ b/src/UI/PluginUI.cs
@@ -114,7 +114,7 @@ namespace GCDTracker.UI {
                 ImGui.End();
             }
 
-            if (conf.FloatingTrianglesEnable) {
+            if (conf.FloatingTrianglesEnable || conf.WindowMoveableSQI) {
                 SetupWindow("GCDTracker_SlideQueueIndicators", conf.WindowMoveableSQI);
                 gcd.DrawFloatingTriangles(this);
                 ImGui.End();

--- a/src/UI/PluginUI.cs
+++ b/src/UI/PluginUI.cs
@@ -9,8 +9,6 @@ using System.Numerics;
 namespace GCDTracker.UI {
     public class PluginUI {
         public bool IsVisible { get; set; }
-        private readonly Easing alertAnimEnabled;
-        private readonly Easing alertAnimPos;
         public GCDDisplay gcd;
         public GCDHelper helper;       
         public ComboTracker ct;
@@ -20,19 +18,9 @@ namespace GCDTracker.UI {
         public Vector2 w_size;
         public float Scale;
         private ImDrawListPtr draw;
-        private readonly string[] alertText;
 
         public PluginUI(Configuration conf) {
             this.conf = conf;
-            alertAnimEnabled = new OutCubic(new(0, 0, 0, 2, 1000)) {
-                Point1 = new(0.25f, 0),
-                Point2 = new(1f, 0)
-            };
-            alertAnimPos = new OutCubic(new(0, 0, 0, 1, 500)) {
-                Point1 = new(0, 0),
-                Point2 = new(0, -20)
-            };
-            alertText = ["CLIP", "0.0", "0.00", "A-B-C"];
         }
 
         public void Draw() {
@@ -176,18 +164,10 @@ namespace GCDTracker.UI {
             draw.AddLine(from + new Vector2(vx, -vy), to - new Vector2(circRad, 0), ImGui.GetColorU32(conf.backCol), 3f * Scale);
         }
 
-        public void StartAlert(bool isClip, float ms) {
-            if (isClip) {
-                alertText[1] = string.Format("{0:0.0}", ms);
-                alertText[2] = string.Format("{0:0.00}", ms);
-            }
-            alertAnimEnabled.Restart();
-            alertAnimPos.Restart();
-        }
-
         public void DrawAlert(float relx, float rely, float textSize, Vector4 textCol, Vector4 backCol, int alertTextPrecision = 0) {
-            if (!alertAnimEnabled.IsRunning || alertAnimEnabled.IsDone) return;
-            if (alertTextPrecision > alertText.Length - 1){
+            var notify = GCDEventHandler.Instance;
+
+            if (alertTextPrecision > notify.alertText.Length - 1){
                 GCDTracker.Log.Error("Alert text precision invalid");
                 return;
             }
@@ -195,7 +175,7 @@ namespace GCDTracker.UI {
                 ImGui.PushFont(UiBuilder.MonoFont);
             ImGui.SetWindowFontScale(textSize);
 
-            var textSz = ImGui.CalcTextSize(alertText[alertTextPrecision]);
+            var textSz = ImGui.CalcTextSize(notify.alertText[alertTextPrecision]);
             var textStartPos =
                 w_cent
                 - (w_size / 2)
@@ -203,11 +183,11 @@ namespace GCDTracker.UI {
                 - (textSz / 2);
             var padding = new Vector2(10, 5) * textSize;
 
-            if (!alertAnimEnabled.IsDone) alertAnimEnabled.Update();
-            if (!alertAnimPos.IsDone) alertAnimPos.Update();
+            if (!notify.alertAnimEnabled.IsDone) notify.alertAnimEnabled.Update();
+            if (!notify.alertAnimPos.IsDone) notify.alertAnimPos.Update();
 
-            var animAlpha = alertAnimEnabled.EasedPoint.X;
-            var animPos = alertAnimPos.EasedPoint;
+            var animAlpha = notify.alertAnimEnabled.EasedPoint.X;
+            var animPos = notify.alertAnimPos.EasedPoint;
 
             draw.AddRectFilled(
                 textStartPos - padding + animPos,
@@ -216,7 +196,7 @@ namespace GCDTracker.UI {
             draw.AddText(
                 textStartPos + animPos,
                 ImGui.GetColorU32(textCol.WithAlpha(1-animAlpha)),
-                alertText[alertTextPrecision]);
+                notify.alertText[alertTextPrecision]);
 
             ImGui.SetWindowFontScale(1f);
             if (conf.OverrideDefaltFont)
@@ -356,46 +336,6 @@ namespace GCDTracker.UI {
             }
 
             draw.Flags = originalFlags;
-        }
-
-        public void DrawParallelogramFilledNoAA(Vector2 p1, Vector2 p2, Vector2 p3, Vector2 p4, Vector4 color) {
-            var originalFlags = draw.Flags;
-            draw.Flags &= ~ImDrawListFlags.AntiAliasedFill;
-
-            draw.AddQuadFilled(p1, p2, p3, p4, ImGui.GetColorU32(color));
-
-            draw.Flags = originalFlags;
-        }
-
-        public void DrawRectNoAA(Vector2 start, Vector2 end, Vector4 color, int thickness) {
-            var originalFlags = draw.Flags;
-            draw.Flags &= ~ImDrawListFlags.AntiAliasedFill;
-            draw.AddRect(start, end, ImGui.GetColorU32(color), 0, ImDrawFlags.None, thickness);
-            draw.Flags = originalFlags;
-        }
-        public void DrawDebugText(float relx, float rely, float textSize, Vector4 textCol, Vector4 backCol, string debugText) {
-            ImGui.PushFont(UiBuilder.MonoFont);
-            ImGui.SetWindowFontScale(textSize);
-
-            var textSz = ImGui.CalcTextSize(debugText);
-            var textStartPos =
-                w_cent
-                - (w_size / 2)
-                + new Vector2(w_size.X * relx, w_size.Y * rely)
-                - (textSz / 2);
-            var padding = new Vector2(10, 5) * textSize;
-
-            draw.AddRectFilled(
-                textStartPos - padding,
-                textStartPos + textSz + padding,
-                ImGui.GetColorU32(backCol), 10f);
-            draw.AddText(
-                textStartPos,
-                ImGui.GetColorU32(textCol),
-                debugText);
-
-            ImGui.SetWindowFontScale(1f);
-            ImGui.PopFont();
         }
     }
 }

--- a/src/UI/PluginUI.cs
+++ b/src/UI/PluginUI.cs
@@ -224,7 +224,7 @@ namespace GCDTracker.UI {
         }
 
         public void DrawTextOutline(Vector2 textPos, Vector4 textColor, string text, float outlineThickness) {
-                Vector4 calculatedOutlineColor = new Vector4(1f, 1f, 1f, textColor.W);
+            Vector4 calculatedOutlineColor = new Vector4(1f, 1f, 1f, textColor.W);
             if (((textColor.X * 0.3f) + (textColor.Y * 0.6f) + (textColor.Z * 0.2f)) > 0.7f)
                 calculatedOutlineColor = new Vector4(0f, 0f, 0f, textColor.W);
             uint outlineColor = ImGui.GetColorU32(calculatedOutlineColor);


### PR DESCRIPTION
Here's our starting point for these changes.

I've started a bit with making a generic GCDNotifier class that can be called as a one-stop-shop for event notifications.  That works pretty well for simple things like the Flyout Clipped/ABC alerts or changing the bar background color.

However, I'm not really sure where to start with the bar coloration and size modification.  The function is so integrated into the workings of the bar I'm not even sure how you'd start to call it from an outside class or method.  Right now I'm working under the assumption that we will set some bools inside our Notifier class and then BarInfo will watch for them and act accordingly.  However, this is problematic because I already ruled out using some kind of iteration based animation approach and instead decided to use the bar progress itself as the timer.

This presents a problem: if we are going to activate this function from outside the BarInfo class, we now need to pass the start-time along with the bool to activate the function (that's pretty straightforward).  The Pulse functions are already set up to take a generic start time so we are good there.  But, we need to track when this is finished and turn off the bool for the next iteration -- (that's pretty straightforward as well -- we can do that when we get to the end of the animation sequence).  But now we have a problem: if somehow the user cancels the cast during an animation, we've left the flag on and that's not ideal.  So we need a place to reset the bool and that's not obvious/intuitive.  I'll keep plugging on it and see if I can come up with a good solution.

It kind of looks like there will just be a bunch of back-and-forth between BarInfo and GCDNotifier:

1. BarInfo will tell the notifier that an event has happened
2. Notifier will set the bool to do the event and cache a start time.
3. BarInfo will actually do the animation
4. BarInfo will then reset the bools and clear the cached start time.

Which sort of asks the question why bother with any of the abstraction?  The wheel is much more straightforward because the time it triggers is always the same, and it can safely be reset each time the GCD starts.

I'm going to have a sleep on it and think about it.  I like being able to do:

```
notify.Now(EventType.FlyOutAlert, EventReason.ABC, location.X, location.Y)
```
But that works well because the GCDNotifier can actually tell ui.Draw to draw the notification.  The GCDNotifier can't actually perform the size/color modifications unless we move BarInfo inside the GCDNotifier.  And I'm not sure that makes sense.

Edit: Unless we wanted to put the notifier into the main loop and execute it every iteration.  I had it set up to be invoked as needed but I suppose we could also place events in a queue for the Notifier to process when it runs in the loop.